### PR TITLE
Fix issue with NetworkService

### DIFF
--- a/BrainUp/BrainUp/Network/AlamofireNetworkService.swift
+++ b/BrainUp/BrainUp/Network/AlamofireNetworkService.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 
 class AlamofireNetworkService: NetworkService {
-    func fetch<T>(_ request: Request, completion: @escaping (Result<T, Error>) -> Void) where T: Decodable {
+    func fetch<T>(_ request: Request, model: T.Type, completion: @escaping (Result<T, Error>) -> Void) where T: Decodable {
         AF.request(request.baseURL+request.path, method: request.method.getAFHTTPMethod(),
                    parameters: request.queryItems,
                    encoding: request.encoding.getAFEncoding(),

--- a/BrainUp/BrainUp/Network/NetworkService.swift
+++ b/BrainUp/BrainUp/Network/NetworkService.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol NetworkService {
-    func fetch<T: Decodable>(_ request: Request, completion: @escaping (Result<T, Error>) -> Void)
+    func fetch<T: Decodable>(_ request: Request, model: T.Type, completion: @escaping (Result<T, Error>) -> Void)
 }

--- a/BrainUp/BrainUp/Network/Request.swift
+++ b/BrainUp/BrainUp/Network/Request.swift
@@ -12,7 +12,8 @@ protocol Request {
     var path: String {get}
     var method: HTTPMethod {get}
     var headers: [String: String] {get}
-    var queryItems: [String: Any] { get }
+    // parameters which are included inside of the request body
+    var parameters: [String: Any]? { get }
     var encoding: Encoding {get}
 }
 
@@ -20,7 +21,7 @@ extension Request {
     var headers: [String: String] {
         [:]
     }
-    var queryItems: [String: Any] {
-        [:]
+    var parameters: [String: Any]? {
+        nil
     }
 }


### PR DESCRIPTION
Was Added parameter model: T.Type to fetch func inside NetworkService. Without this fix you get error: "Generic parameter 'T' could not be inferred"

Was changed name of queryItems inside Request protocol to parameters, because this value is settled in body of request by alamofire.